### PR TITLE
Fixed typo in NSIS.template.in: plesae ==> please

### DIFF
--- a/Installation/Windows/Templates/NSIS.template.in
+++ b/Installation/Windows/Templates/NSIS.template.in
@@ -160,7 +160,7 @@ ${Case} 0
 	${IfThen} $1 = 1 ${|} Quit ${|} ;we are the outer process, the inner process has done its work, we are done
 	${IfThen} $3 <> 0 ${|} ${Break} ${|} ;we are admin, let the show go on
 	${If} $1 = 3 ;RunAs completed successfully, but with a non-admin user
-		MessageBox mb_YesNo|mb_IconExclamation|mb_TopMost|mb_SetForeground "Administrator privileges required, plesae try again" /SD IDNO IDYES uac_tryagain IDNO 0
+		MessageBox mb_YesNo|mb_IconExclamation|mb_TopMost|mb_SetForeground "Administrator privileges required, please try again" /SD IDNO IDYES uac_tryagain IDNO 0
 	${EndIf}
 	;fall-through and die
 ${Case} 1223


### PR DESCRIPTION
I noticed this typo during installation.
